### PR TITLE
Updated job-dsl-core to 1.25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0", {
         exclude module: "groovy-all"
     }
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.24'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.25'
 }
 
 defaultTasks "clean", "build", "installApp"

--- a/src/main/groovy/com/sheehan/jobdsl/DslScriptExecutor.groovy
+++ b/src/main/groovy/com/sheehan/jobdsl/DslScriptExecutor.groovy
@@ -1,5 +1,6 @@
 package com.sheehan.jobdsl
 
+import javaposse.jobdsl.dsl.ConfigFileType
 import javaposse.jobdsl.dsl.DslScriptLoader
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.JobParent
@@ -32,6 +33,7 @@ class DslScriptExecutor implements ScriptExecutor {
                 getPluginVersion: { String pluginShortName -> null },
                 logDeprecationWarning: {},
                 getCredentialsId: { String credentialsDescription -> null },
+                getConfigFileId: { ConfigFileType type, String name -> UUID.randomUUID().toString() },
                 createOrUpdateConfig: { String name, String xml, Boolean ignoreExisting -> true }
             ] as JobManagement
 

--- a/src/ratpack/templates/index.html
+++ b/src/ratpack/templates/index.html
@@ -72,7 +72,7 @@ job {
                 the website source <a href="https://github.com/sheehan/job-dsl-playground">here</a>.
             </p>
             <p>
-                Job DSL version: 1.24
+                Job DSL version: 1.25
             </p>
         </div>
         <div class="code-wrapper">


### PR DESCRIPTION
I added a dummy implementation for JobManagement#getConfigFileId which returns a random id, so that DSL methods using that method can be used on the playground.
