### PR TITLE
Use version from manifest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
         assetPipelineVersion = "2.7.2"
+        jobDslVersion = "1.46"
     }
     repositories {
         maven { url "http://oss.jfrog.org/artifactory/repo" }
@@ -54,12 +55,18 @@ dependencies {
     // Default SLF4J binding. Note that this is a blocking implementation.
     // See here for a non blocking appender http://logging.apache.org/log4j/2.x/manual/async.html
     runtime 'org.slf4j:slf4j-simple:1.7.7'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.46'
+    compile "org.jenkins-ci.plugins:job-dsl-core:${jobDslVersion}"
 
     compile "com.bertramlabs.plugins:ratpack-asset-pipeline:${assetPipelineVersion}"
     runtime "com.bertramlabs.plugins:less-asset-pipeline:${assetPipelineVersion}"
 
     testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
+}
+
+shadowJar {
+    manifest {
+        attributes 'Implementation-Version': jobDslVersion
+    }
 }
 
 task stage {

--- a/src/ratpack/templates/index.html
+++ b/src/ratpack/templates/index.html
@@ -72,7 +72,7 @@ job('ci') {
 </div>
 </div>
 <div class="footer">
-    <span class="version">Job DSL version: 1.46</span>
+    <span class="version">Job DSL version: ${javaposse.jobdsl.dsl.DslFactory.package.implementationVersion}</span>
     <span class="playground-source"><a href="https://github.com/sheehan/job-dsl-playground">Source</a></span>
 </div>
 


### PR DESCRIPTION
The shadow plugin introduced in https://github.com/sheehan/job-dsl-playground/commit/81c936981726e8abddc27a83201fd5311acf5c7a does not keep the manifests from the shadowed JARs. Setting the version in the shadow JAR manifest instead.