### PR TITLE
Fix repository locations.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:8
+WORKDIR /usr/src
+COPY . /usr/src
+RUN /usr/src/gradlew build
+CMD [ "./gradlew", "run" ]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,7 @@ You can run the app locally with:
 ./gradlew run
 ```
 
-<<<<<<< HEAD
-Or build a dockker image using the locally included Dockerfile.
-=======
 Or build a docker image using the locally included Dockerfile.
->>>>>>> b2205ac (Updated build repository location.)
 
 ```
 docker build -t dsl-playground .

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ You can run the app locally with:
 ./gradlew run
 ```
 
+<<<<<<< HEAD
 Or build a dockker image using the locally included Dockerfile.
+=======
+Or build a docker image using the locally included Dockerfile.
+>>>>>>> b2205ac (Updated build repository location.)
 
 ```
 docker build -t dsl-playground .

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ You can run the app locally with:
 ./gradlew run
 ```
 
-Or use the docker image provided by [@ewypych](https://github.com/ewypych):
+Or build a dockker image using the locally included Dockerfile.
+
+```
+docker build -t dsl-playground .
+docker run -p 5050:5050 dsl-playground
+```
 
 https://github.com/ewypych/docker-job-dsl-playground

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jobDslVersion = "1.77"
     }
     repositories {
-        maven { url "http://oss.jfrog.org/artifactory/repo" }
+        mavenCentral()
         jcenter()
     }
     dependencies {
@@ -41,10 +41,8 @@ idea {
 apply plugin: "eclipse"
 
 repositories {
-  maven { url "http://oss.jfrog.org/artifactory/repo" }
-  jcenter()
-  maven { url "http://repo.springsource.org/repo" } // for springloaded
-  maven { url "http://repo.jenkins-ci.org/releases/" }
+  mavenCentral()
+  maven { url "https://repo.jenkins-ci.org/releases/" }
 }
 
 configurations.all {


### PR DESCRIPTION
Gradle builds have been failing since repository locations are now outdated. This build will fix that, and also include a locally buildable docker image.